### PR TITLE
Limit backoff so that it stops upon reaching max duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ $ csv-to-influxdb --help
   Options:
   --server, -s             Server address (default http://localhost:8086)
   --database, -d           Database name (default test)
+  --username, -u           User name
+  --password, -p           Password
   --measurement, -m        Measurement name (default data)
   --batch-size, -b         Batch insert size (default 5000)
   --tag-columns, -t        Comma-separated list of columns to use as tags
@@ -34,6 +36,8 @@ $ csv-to-influxdb --help
   --timestamp-format, -tf  Timestamp format used to parse all timestamp
                            records (default 2006-01-02 15:04:05)
   --no-auto-create, -n     Disable automatic creation of database
+  --attempts, -a           Maximum number of attempts to send data to
+                           influxdb before failing
   --help, -h
   --version, -v
 

--- a/main.go
+++ b/main.go
@@ -23,6 +23,8 @@ type config struct {
 	CSVFile         string `type:"arg" help:"<csv-file> must be a path a to valid CSV file with an initial header row"`
 	Server          string `help:"Server address"`
 	Database        string `help:"Database name"`
+	Username        string `help:"User name"`
+	Password        string `help:"Password"`
 	Measurement     string `help:"Measurement name"`
 	BatchSize       int    `help:"Batch insert size"`
 	TagColumns      string `help:"Comma-separated list of columns to use as tags instead of fields"`
@@ -37,6 +39,8 @@ func main() {
 	conf := config{
 		Server:          "http://localhost:8086",
 		Database:        "test",
+		Username:        "",
+		Password:        "",
 		Measurement:     "data",
 		BatchSize:       5000,
 		TimestampColumn: "timestamp",
@@ -76,12 +80,13 @@ func main() {
 	//if err != nil {
 	//	log.Fatalf("Invalid server address: %s", err)
 	//}
-	c, err := client.NewHTTPClient(client.HTTPConfig{Addr: conf.Server})
-
+	c, err := client.NewHTTPClient(client.HTTPConfig{Addr: conf.Server, Username: conf.Username, Password: conf.Password})
+	
 	dbsResp, err := c.Query(client.Query{Command: "SHOW DATABASES"})
 	if err != nil {
-		log.Fatalf("Invalid server address: %s", err)
+        log.Fatalf("Invalid server address: %s", err)
 	}
+
 	dbExists := false
 	for _, v := range dbsResp.Results[0].Series[0].Values {
 		dbName := v[0].(string)

--- a/main.go
+++ b/main.go
@@ -84,7 +84,7 @@ func main() {
 	
 	dbsResp, err := c.Query(client.Query{Command: "SHOW DATABASES"})
 	if err != nil {
-        log.Fatalf("Invalid server address: %s", err)
+		log.Fatalf("Invalid server address: %s", err)
 	}
 
 	dbExists := false

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-//	"net/url"
 	"os"
 	"regexp"
 	"strconv"
@@ -31,6 +30,7 @@ type config struct {
 	TimestampColumn string `short:"ts" help:"Header name of the column to use as the timestamp"`
 	TimestampFormat string `short:"tf" help:"Timestamp format used to parse all timestamp records"`
 	NoAutoCreate    bool   `help:"Disable automatic creation of database"`
+	Attempts        int    `help:"Maximum number of attempts to send data to influxdb before failing"`
 }
 
 func main() {
@@ -66,7 +66,6 @@ func main() {
 	//regular expressions
 	numbersRe := regexp.MustCompile(`\d`)
 	integerRe := regexp.MustCompile(`^\d+$`)
-//	floatRe := regexp.MustCompile(`^\d+\.\d+$`)
 	floatRe := regexp.MustCompile(`^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$`)
 	trueRe := regexp.MustCompile(`^(true|T|True|TRUE)$`)
 	falseRe := regexp.MustCompile(`^(false|F|False|FALSE)$`)
@@ -153,19 +152,15 @@ func main() {
 		if bpSize == 0 {
 			return
 		}
-		b := backoff.Backoff{Max: 2 * time.Second}
-		prevD := time.Nanosecond
+		b := backoff.Backoff{}
 		for {
 			if err := c.Write(bp); err != nil {
 				d := b.Duration()
-				if d == prevD {
-					if err != nil {
-           	        	log.Fatalf("failed to write to db")
-                   	}
-				}
 				log.Printf("Write failed: %s (retrying in %s)", err, d)
+				if int(b.Attempt()) == conf.Attempts {
+					log.Fatalf("Failed to write to db after %d attempts", int(b.Attempt()))
+				}
 				time.Sleep(d)
-				prevD = d
 				continue
 			}
 			break

--- a/main.go
+++ b/main.go
@@ -148,12 +148,19 @@ func main() {
 		if bpSize == 0 {
 			return
 		}
-		b := backoff.Backoff{}
+		b := backoff.Backoff{Max: 2 * time.Second}
+		prevD := time.Nanosecond
 		for {
 			if err := c.Write(bp); err != nil {
 				d := b.Duration()
+				if d == prevD {
+					if err != nil {
+           	        	log.Fatalf("failed to write to db")
+                   	}
+				}
 				log.Printf("Write failed: %s (retrying in %s)", err, d)
 				time.Sleep(d)
+				prevD = d
 				continue
 			}
 			break

--- a/main.go
+++ b/main.go
@@ -80,13 +80,16 @@ func main() {
 	//	log.Fatalf("Invalid server address: %s", err)
 	//}
 	c, err := client.NewHTTPClient(client.HTTPConfig{Addr: conf.Server, Username: conf.Username, Password: conf.Password})
-	
+
 	dbsResp, err := c.Query(client.Query{Command: "SHOW DATABASES"})
 	if err != nil {
 		log.Fatalf("Invalid server address: %s", err)
 	}
 
 	dbExists := false
+	if len(dbsResp.Results) == 0 {
+		log.Fatalf("No databases found, probably an authentication issue, please provide username and password.")
+	}
 	for _, v := range dbsResp.Results[0].Series[0].Values {
 		dbName := v[0].(string)
 		if conf.Database == dbName {


### PR DESCRIPTION
Currently the retries never stop in case the write failed (for instance when there is a collision of field types).
