### PR TITLE
add option to insert numeric values as strings

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ type config struct {
 	TimestampFormat string `short:"tf" help:"Timestamp format used to parse all timestamp records"`
 	NoAutoCreate    bool   `help:"Disable automatic creation of database"`
 	ForceFloat      bool   `help:"Force all numeric values to insert as float"`
+	ForceString     bool   `help:"Force all numeric values to insert as string"`
 	Attempts        int    `help:"Maximum number of attempts to send data to influxdb before failing"`
 }
 
@@ -45,6 +46,7 @@ func main() {
 		Measurement:     "data",
 		BatchSize:       5000,
 		ForceFloat:      false,
+		ForceString:     false,
 		TimestampColumn: "timestamp",
 		TimestampFormat: "2006-01-02 15:04:05",
 	}
@@ -229,10 +231,10 @@ func main() {
 					continue
 				}
 				fields[h] = t
-			} else if !conf.ForceFloat && integerRe.MatchString(r) {
+			} else if !conf.ForceFloat && !conf.ForceString && integerRe.MatchString(r) {
 				i, _ := strconv.Atoi(r)
 				fields[h] = i
-			} else if floatRe.MatchString(r) {
+			} else if !conf.ForceString && floatRe.MatchString(r) {
 				f, _ := strconv.ParseFloat(r, 64)
 				fields[h] = f
 			} else if trueRe.MatchString(r) {


### PR DESCRIPTION
Since fields are scanned for types on a row-by-row basis, it can happen that a string value is mistaken for a numeric (e.g. with values such as '1234', '123x', ...).  This creates a problem as inserting values of different types is not supported.  This option would simply insert all fields as strings, with the exception of timestamps.

A better solution might have been to have the possibility to specify the column types, or to infer them based on a subset of the CSV, rather than independently for each row.  But implementing these would involve more effort.
