### PR TITLE
Allow unix timestamp parsing

### DIFF
--- a/main.go
+++ b/main.go
@@ -271,9 +271,6 @@ func main() {
 
 			//fields require string parsing
 			if conf.TimestampColumn == h {
-
-				fmt.Printf("JB: at timestamp column\n")
-
 				if conf.TimestampFormat == "unix" {
 					ts, err = parseUnixTimestamp(r)
 

--- a/main.go
+++ b/main.go
@@ -75,15 +75,9 @@ func main() {
 	floatRe := regexp.MustCompile(`^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$`)
 	trueRe := regexp.MustCompile(`^(true|T|True|TRUE)$`)
 	falseRe := regexp.MustCompile(`^(false|F|False|FALSE)$`)
-	var timestampRe
-	if conf.TimestampFormat == "unix" {
-		timestampRe = nil
-		err := nil
-	} else {
-		timestampRe, err := regexp.Compile("^" + numbersRe.ReplaceAllString(conf.TimestampFormat, `\d`) + "$")
-		if err != nil {
-			log.Fatalf("time stamp regexp creation failed")
-		}
+	timestampRe, err := regexp.Compile("^" + numbersRe.ReplaceAllString(conf.TimestampFormat, `\d`) + "$")
+	if err != nil {
+		log.Fatalf("time stamp regexp creation failed")
 	}
 
 	//influxdb client
@@ -232,25 +226,25 @@ func main() {
 			if conf.TimestampColumn == h {
 				//the timestamp column!
 
-				if conf.TimestampFormat ==  {
+				if conf.TimestampFormat == "unix" {
 					t, err := time.Parse(conf.TimestampFormat, r)
 					if err != nil {
 						fmt.Printf("#%d: %s: Invalid time: %s\n", i, h, err)
 						continue
 					}
+					ts = t
 				} else if timestampRe.MatchString(r) {
 					ti, err := strconv.ParseInt(r, 10, 64)
 					if err != nil {
 						fmt.Printf("#%d: %s: Invalid time: %s\n", i, h, err)
 						continue
 					}
-					tm := time.Unix(ti, 0)
+					ts = time.Unix(ti, 0)
 				} else {
 					fmt.Printf("#%d: %s: Invalid time: not mathing format\n", i, h)
 					continue
 				}
 
-				ts = t
 				continue
 
 			} else if timestampRe != nil && timestampRe.MatchString(r) {

--- a/main.go
+++ b/main.go
@@ -189,7 +189,7 @@ func main() {
 		bpSize = 0
 	}
 
-	parseUnixTimestamp := func(unixTmstmp string) (ts time.Time, outErr) {
+	parseUnixTimestamp := func(unixTmstmp string) (ts time.Time, outErr error) {
 		var duration_Milliseconds time.Duration = time.Duration(0)
 		if len(unixTmstmp) >= 13 {
 			ms_string := unixTmstmp[10:13]
@@ -272,8 +272,11 @@ func main() {
 			//fields require string parsing
 			if conf.TimestampColumn == h {
 
+				fmt.Printf("JB: at timestamp column\n")
+
 				if conf.TimestampFormat == "unix" {
 					ts, err = parseUnixTimestamp(r)
+
 					if err != nil {
 						fmt.Printf("#%d: %s: Invalid time: %s\n", i, h, err)
 						continue


### PR DESCRIPTION
The code should support parsing unix timestamps in seconds, milliseconds, microseconds and nanoseconds.

Please bear in mind that I have little to no experience writing Go, so their might be some conventions I didn't respect.
