### PR TITLE
parse timestamp column as integer timestamp value like influxdb would

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,8 +86,11 @@ func main() {
 	//	log.Fatalf("Invalid server address: %s", err)
 	//}
 	c, err := client.NewHTTPClient(client.HTTPConfig{Addr: conf.Server, Username: conf.Username, Password: conf.Password, Timeout: time.Duration(conf.HttpTimeout) * time.Second})
+	if err != nil {
+		log.Fatalf("Could not connect to server: %s", err)
+	}
 	defer c.Close()
-	
+
 	dbsResp, err := c.Query(client.Query{Command: "SHOW DATABASES"})
 	if err != nil {
 		log.Fatalf("Invalid server address: %s", err)

--- a/main.go
+++ b/main.go
@@ -254,11 +254,15 @@ func main() {
 					fmt.Printf("#%d: %s: Invalid time: %s\n", i, h, err)
 					continue
 				}
-				seconds := f * (timeFactor / secondsFactor)
+				seconds := uint64(0)
 				nanos := uint64(0)
 				if secondsFactor > timeFactor {
+					seconds = f / (secondsFactor / timeFactor)
 					nanos = (f % (secondsFactor / timeFactor)) * timeFactor
+				} else {
+					seconds = f * (timeFactor / secondsFactor)
 				}
+				ts = time.Unix(int64(seconds), int64(nanos))
 				ts = time.Unix(int64(seconds), int64(nanos))
 			} else if !conf.ForceFloat && !conf.ForceString && integerRe.MatchString(r) {
 				i, _ := strconv.Atoi(r)

--- a/main.go
+++ b/main.go
@@ -37,12 +37,12 @@ type config struct {
 }
 
 var plainTimeValues = map[string]uint64{
-	"n":  1,
-	"u":  1000,
-	"ms": 1000000,
-	"s":  1000000000,
-	"m":  60000000000,
-	"h":  60 * 60000000000,
+	"n":  uint64(time.Nanosecond),
+	"u":  uint64(time.Microsecond),
+	"ms": uint64(time.Millisecond),
+	"s":  uint64(time.Second),
+	"m":  uint64(time.Minute),
+	"h":  uint64(time.Hour),
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -263,7 +263,6 @@ func main() {
 					seconds = f * (timeFactor / secondsFactor)
 				}
 				ts = time.Unix(int64(seconds), int64(nanos))
-				ts = time.Unix(int64(seconds), int64(nanos))
 			} else if !conf.ForceFloat && !conf.ForceString && integerRe.MatchString(r) {
 				i, _ := strconv.Atoi(r)
 				fields[h] = i


### PR DESCRIPTION
If the time format is any of (h, m, s, ms, u, ns) the timestamp column will be parsed as integer with the given precission (instead of a formatted string), mimicking the behaviour of the influxdb line write API using the given precission.
(please don't hurt me if there is anything wrong with my code, these are the first lines of Go that I ever wrote)