### PR TITLE
Custom delimiter, Skip lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ $ csv-to-influxdb --help
   --treat-null             Force treating "null" string values as such
   --attempts, -a           Maximum number of attempts to send data to
                            influxdb before failing
+  --skip,                  Skip n lines at the beginning of the csv file
+  --delimiter              Set a custom csv delimiter (default ",")
   --help, -h
   --version, -v
 


### PR DESCRIPTION
Hey,

I added a possibility to use a custom delimiter since not every csv is delimited by ','.
Besides that, some csv files have more than one header line, so skipping some lines at
the beginning seems to be a great functionality. 